### PR TITLE
在Monaco Editor组件增加按钮用于弹出一个较大的模态框，方便编辑代码

### DIFF
--- a/src/comps/map/AMapConfig.tsx
+++ b/src/comps/map/AMapConfig.tsx
@@ -55,7 +55,8 @@ export const AMapConfig: React.FC<ConfigType<AMapController>> = ({controller}) =
                         value: codeRef.current,
                         config: {
                             language: 'javascript',
-                            height: 600
+                            height: 600,
+                            showExtend: true
                         }
                     }
                 ]

--- a/src/designer/Designer.tsx
+++ b/src/designer/Designer.tsx
@@ -14,6 +14,8 @@ import Loading from "../json-schema/ui/loading/Loading";
 import FrameLayout from "../json-schema/ui/frame-layout/FrameLayout";
 import {SaveType} from "./DesignerType.ts";
 import designerManager from "./manager/DesignerManager.ts";
+import MonacoEditorDialog from "../json-schema/ui/code-editor/MonacoEditorDialog.tsx";
+import monacoEditorDialogManager from "../json-schema/ui/code-editor/MonacoEditorDialogManager.ts";
 
 
 /**
@@ -103,6 +105,7 @@ const Designer = (props: DesignerProps) => {
                          content={<DesignerCanvas/>}
                          right={<DesignerRight/>}
                          footer={<DesignerFooter/>}/>
+            {monacoEditorDialogManager.visible && <MonacoEditorDialog/>}
         </div>
     );
 }

--- a/src/json-schema/SchemaTypes.ts
+++ b/src/json-schema/SchemaTypes.ts
@@ -55,6 +55,7 @@ export interface CodeEditorConfigType extends BaseSchemaType {
         language?: 'json' | 'javascript' | 'sql';
         width?: string | number;
         height?: string | number;
+        showExtend?: boolean;
     }
 }
 

--- a/src/json-schema/ui/code-editor/MonacoEditor.less
+++ b/src/json-schema/ui/code-editor/MonacoEditor.less
@@ -1,3 +1,25 @@
 .monaco-editor-container {
   border: 2px solid #2d2d2d;
 }
+
+.monaco-editor-main {
+}
+
+.monaco-editor-buttom-bar {
+  border-top: 2px solid #2d2d2d;
+  width: 100%;
+  display: flex;
+  padding: 0px 5px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-content: center;
+  justify-content: space-between;
+  align-items: center;
+  .monaco-editor-status-item {
+    padding-right: 5px;
+  }
+  .left-border {
+    border-left: 2px solid #2d2d2d;
+    padding-left: 5px;
+  }
+}

--- a/src/json-schema/ui/code-editor/MonacoEditor.tsx
+++ b/src/json-schema/ui/code-editor/MonacoEditor.tsx
@@ -1,5 +1,6 @@
 import Loading from "../loading/Loading";
-import Editor, {loader} from "@monaco-editor/react";
+import { useRef, useState } from 'react';
+import Editor, {loader, Monaco} from "@monaco-editor/react";
 import './MonacoEditor.less';
 
 import * as monaco from 'monaco-editor';
@@ -7,6 +8,10 @@ import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution';
+import { Button } from "antd";
+import { Extend } from '@icon-park/react';
+import MonacoEditorDialog from "./MonacoEditorDialog";
+import monacoEditorDialogManager from "./MonacoEditorDialogManager";
 
 self.MonacoEnvironment = {
     getWorker(_, label) {
@@ -28,34 +33,74 @@ export interface MonacoEditorProps {
     language?: 'javascript' | 'json' | 'sql';
     width?: string | number;
     height?: string | number;
+    showExtend?: boolean;
 }
 
 export default function MonacoEditor(props: MonacoEditorProps) {
-    const {value, defaultValue, onChange, language, width, height, readonly} = props;
+    const {value, defaultValue, onChange, language, width, height, readonly, showExtend} = props;
+    console.log(props)
+    const monacoRef = useRef(null);
+    const editorRef = useRef(null);
+    const [currentLine, setCurrentLine] = useState(1);
+    const [currentCol, setCurrentCol] = useState(1);
+
+    function handleEditorDidMount(editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) {
+        editor.onDidChangeCursorPosition(()=>{
+            const pos = editor.getPosition()
+            if(pos){
+                setCurrentLine(pos.lineNumber);
+                setCurrentCol(pos.column);
+            }
+        })
+        editorRef.current = editor;
+        monacoRef.current = monaco;
+    }
+
+    const handleDialogOpen = () => {
+        monacoEditorDialogManager.setCloseHandler(handleDialogClose);
+        monacoEditorDialogManager.setProps({...props,showExtend: false});
+        monacoEditorDialogManager.setVisibility(true);
+    }
+
+    const handleDialogClose = (props: MonacoEditorProps) => {
+        editorRef.current.setValue(props.value ? props.value : props.defaultValue);
+        monacoEditorDialogManager.resetCloseHandler();
+    }
+
     return (
-        <div style={{width, height}} className={'monaco-editor-container'}>
-            <Editor defaultLanguage={language || 'json'}
-                    theme="vs-dark"
-                    onChange={onChange}
-                    height={'100%'}
-                    width={'100%'}
-                    options={{
-                        minimap: {enabled: false},
-                        quickSuggestions: false,
-                        folding: false,
-                        readOnly: readonly || false,
-                        renderValidationDecorations: 'off',
-                        mouseWheelZoom: true,
-                        scrollBeyondLastLine: false,
-                        renderLineHighlight: 'none',
-                        hideCursorInOverviewRuler: true,
-                        overviewRulerLanes: 0,
-                        overviewRulerBorder: false,
-                    }}
-                    loading={<Loading/>}
-                    value={value}
-                    defaultValue={defaultValue}
-            />
+        <div className={'monaco-editor-container'}>
+            <div style={{width, height}} className={'monaco-editor-main'}>
+                <Editor defaultLanguage={language || 'json'}
+                        theme="vs-dark"
+                        onChange={onChange}
+                        height={'100%'}
+                        width={'100%'}
+                        options={{
+                            minimap: {enabled: false},
+                            quickSuggestions: false,
+                            folding: false,
+                            readOnly: readonly || false,
+                            renderValidationDecorations: 'off',
+                            mouseWheelZoom: true,
+                            scrollBeyondLastLine: false,
+                            renderLineHighlight: 'none',
+                            hideCursorInOverviewRuler: true,
+                            overviewRulerLanes: 0,
+                            overviewRulerBorder: false,
+                        }}
+                        loading={<Loading/>}
+                        value={value}
+                        defaultValue={defaultValue}
+                        onMount={handleEditorDidMount}
+                />
+            </div>
+            <div className={'monaco-editor-buttom-bar'}>
+                <div>
+                    <span className={'monaco-editor-status-item'}>行 {currentLine}, 列 {currentCol}</span>
+                    <span className={'monaco-editor-status-item left-border'}>语言 {language || 'json'}</span>
+                </div>
+                {showExtend && <Button style={{float: 'right'}} type='text' size='small' icon={<Extend />} onClick={handleDialogOpen} />}
+            </div>
         </div>
     )
 }

--- a/src/json-schema/ui/code-editor/MonacoEditorDialog.tsx
+++ b/src/json-schema/ui/code-editor/MonacoEditorDialog.tsx
@@ -1,0 +1,41 @@
+import {observer} from "mobx-react";
+import Dialog from "../dialog/Dialog.tsx";
+import {Grid} from "../grid/Grid.tsx";
+import MonacoEditor from "./MonacoEditor.tsx";
+import Button from "../button/Button.tsx";
+import {useRef} from "react";
+import monacoEditorDialogManager from "./MonacoEditorDialogManager.ts";
+
+const MonacoEditorDialog = observer(() => {
+
+    const { handleClose, setVisibility} = monacoEditorDialogManager;
+
+    const propsRef = useRef(monacoEditorDialogManager.props);
+
+    const onClose = () => {
+        handleClose();
+        setVisibility(false);
+    }
+
+    const onChange = (data:string | undefined) => {
+        propsRef.current.value = data;
+        propsRef.current.onChange && propsRef.current.onChange(data);
+    }
+
+    return <Dialog title={'代码编辑'} visible={true} width={800}
+                   className={'add-filter-dialog'}
+                   onClose={onClose}>
+        <Grid>
+            <MonacoEditor defaultValue={propsRef.current.defaultValue}
+                          value={propsRef.current.value}
+                          language={propsRef.current.language}
+                          showExtend={propsRef.current.showExtend}
+                          onChange={onChange}
+                          height={600}/>
+        </Grid>
+        <div className={'add-filter-dialog-footer'}>
+            <Button onClick={onClose}>关闭</Button>
+        </div>
+    </Dialog>
+})
+export default MonacoEditorDialog;

--- a/src/json-schema/ui/code-editor/MonacoEditorDialogDataType.tsx
+++ b/src/json-schema/ui/code-editor/MonacoEditorDialogDataType.tsx
@@ -1,0 +1,5 @@
+import { MonacoEditorProps } from "./MonacoEditor";
+
+export interface MonacoEditorDialogDataType {
+    props: MonacoEditorProps;
+}

--- a/src/json-schema/ui/code-editor/MonacoEditorDialogManager.ts
+++ b/src/json-schema/ui/code-editor/MonacoEditorDialogManager.ts
@@ -1,0 +1,61 @@
+import {action, makeObservable, observable, toJS} from "mobx";
+import AbstractManager from "../../../designer/manager/core/AbstractManager.ts";
+import { MonacoEditorDialogDataType } from "./MonacoEditorDialogDataType.tsx";
+import { MonacoEditorProps } from "./MonacoEditor.tsx";
+
+class MonacoEditorDialogManager extends AbstractManager<MonacoEditorDialogDataType> {
+    constructor() {
+        super();
+        makeObservable(this, {
+            props: observable,
+            visible: observable,
+            closeHandler: observable,
+            setProps: action,
+            setVisibility: action,
+            setCloseHandler: action,
+            resetCloseHandler: action,
+            handleClose: action
+        })
+
+    }
+
+    props: MonacoEditorProps = {};
+
+    visible: boolean = false;
+
+    closeHandler: (props: MonacoEditorProps)=>void = ()=>{};
+
+    setVisibility = (visible: boolean) => {
+        this.visible = visible;
+        if (!visible){
+            console.log()
+        }
+    };
+
+    setValue = (value?: string) => this.props.value = value;
+
+    setProps = (props: MonacoEditorProps) => this.props = props;
+
+    setCloseHandler = (closeHandler:(props: MonacoEditorProps)=>void) => this.closeHandler = closeHandler;
+
+    resetCloseHandler = () => this.closeHandler = ()=>{};
+
+    handleClose = ():void => {
+        this.closeHandler(toJS(this.props));
+    }
+
+    public init(data: MonacoEditorDialogDataType): void {
+        this.props = data.props || {};
+    }
+
+    public getData(): MonacoEditorDialogDataType {
+        return {props: this.props}
+    }
+
+    public destroy(): void {
+        this.props = {}
+    }
+}
+
+const monacoEditorDialogManager= new MonacoEditorDialogManager();
+export default monacoEditorDialogManager;


### PR DESCRIPTION
在Monaco Editor组件增加按钮用于弹出一个较大的模态框，方便编辑代码
![image](https://github.com/user-attachments/assets/ac9ebe0f-a026-4453-a119-e278e2c759cf)
