### PR TITLE
fix: correct mobx import path in DesignerLoader.ts

### DIFF
--- a/src/designer/loader/DesignerLoader.ts
+++ b/src/designer/loader/DesignerLoader.ts
@@ -14,7 +14,7 @@ import AbstractConvert from "../../framework/convert/AbstractConvert";
 import {componentCategorize} from "../left/compoent-lib/ComponentCategorize";
 import {DesignerMode, ProjectDataType, SaveType} from "../DesignerType.ts";
 import {globalMessage} from "../../framework/message/GlobalMessage.tsx";
-import {action, makeObservable, observable} from "../../../.vite/deps/mobx";
+import {action, makeObservable, observable} from "mobx";
 
 export class DesignerLoader {
 


### PR DESCRIPTION
## Problem
  The import path for mobx in `src/designer/loader/DesignerLoader.ts` was incorrectly set to `../../../.vite/deps/mobx`, which is a Vite cache directory path that doesn't exist in the source code.

  This causes the following error when running `pnpm dev`:
  Failed to resolve import "../../../.vite/deps/mobx" from "src/designer/loader/DesignerLoader.ts". Does the file exist?

  ## Solution
  Changed the import path from:
  ```typescript
  import {action, makeObservable, observable} from "../../../.vite/deps/mobx";
  to:
  import {action, makeObservable, observable} from "mobx";

  Related

  This bug was introduced in commit f9f17cbc when the file was renamed from AbstractDesignerLoader.ts to DesignerLoader.ts.